### PR TITLE
Fixing issue#14

### DIFF
--- a/js/adapt-contrib-background-switcher.js
+++ b/js/adapt-contrib-background-switcher.js
@@ -25,8 +25,8 @@ define([
 			}
 			this._blockModelsIndexed = _.indexBy(this._blockModels, "_id");
 
-			this.listenTo(Adapt, "pageView:ready", this.onPageReady);
-			this.listenTo(Adapt, "remove", this.onRemove);
+			this.listenToOnce(Adapt, "pageView:ready", this.onPageReady);
+			this.listenToOnce(Adapt, "remove", this.onRemove);
 			this.setupBackgroundContainer();
 		},
 


### PR DESCRIPTION
Listeners were not unregistered, because the in `initialize` the `onRemove` could happen before registering listeners we do not need to put unregistering there, and because they are used once per instance I've chose to use `listenToOnce`
